### PR TITLE
fix: apply repository pattern correctly by decoupling event entity from any ORM

### DIFF
--- a/lib/rails_event_store.rb
+++ b/lib/rails_event_store.rb
@@ -1,4 +1,5 @@
 require 'rails_event_store/event_entity'
+require 'rails_event_store/models/event'
 require 'rails_event_store/generators/migrate_generator'
 require 'rails_event_store/generators/templates/migration_template'
 require 'rails_event_store/version'

--- a/lib/rails_event_store/event_entity.rb
+++ b/lib/rails_event_store/event_entity.rb
@@ -1,10 +1,10 @@
-require 'active_record'
+require 'active_model'
 
 module RailsEventStore
-  class EventEntity < ActiveRecord::Base
-    self.primary_key = :id
-    self.table_name = 'event_store_events'
-    serialize :metadata
-    serialize :data
+  class EventEntity
+    include ::ActiveModel::Model
+
+    attr_accessor :id, :stream, :event_type, :event_id,
+                  :metadata, :data, :created_at
   end
 end

--- a/lib/rails_event_store/models/event.rb
+++ b/lib/rails_event_store/models/event.rb
@@ -1,0 +1,12 @@
+require 'active_record'
+
+module RailsEventStore
+  module Models
+    class Event < ::ActiveRecord::Base
+      self.primary_key = :id
+      self.table_name = 'event_store_events'
+      serialize :metadata
+      serialize :data
+    end
+  end
+end

--- a/lib/rails_event_store/repositories/event_repository.rb
+++ b/lib/rails_event_store/repositories/event_repository.rb
@@ -3,54 +3,55 @@ module RailsEventStore
     class EventRepository
 
       def initialize
-        @adapter = EventEntity
+        @adapter = ::RailsEventStore::Models::Event
       end
       attr_reader :adapter
 
       def find(condition)
-        adapter.where(condition).first
+        build_event_entity adapter.where(condition).first
       end
 
       def create(data)
-        begin
-          adapter.create(data)
-        rescue ActiveRecord::RecordNotUnique
-          raise EventCannotBeSaved
-        end
+        build_event_entity adapter.create(data)
+      rescue ActiveRecord::RecordNotUnique
+        raise EventCannotBeSaved
       end
 
       def delete(condition)
         adapter.destroy_all condition
+        nil
       end
 
       def get_all_events
-        adapter.find(:all, order: 'stream').map &method(:map_record)
+        adapter.find(:all, order: 'stream').map &method(:build_event_entity)
       end
 
       def last_stream_event(stream_name)
-        adapter.where(stream: stream_name).last.map &method(:map_record)
+        adapter.where(stream: stream_name).last.map &method(:build_event_entity)
       end
 
       def load_all_events_forward(stream_name)
-        adapter.where(stream: stream_name).order('id ASC').map &method(:map_record)
+        adapter.where(stream: stream_name).order('id ASC').map &method(:build_event_entity)
       end
 
       def load_events_batch(stream_name, start_point, count)
-        adapter.where('id >= ? AND stream = ?', start_point, stream_name).limit(count).map &method(:map_record)
+        adapter.where('id >= ? AND stream = ?', start_point, stream_name).limit(count).map &method(:build_event_entity)
       end
 
       private
 
-      def map_record(record)
-        event_data = {
-            stream:     record.stream,
-            event_type: record.event_type,
-            event_id:   record.event_id,
-            metadata:   record.metadata,
-            data:       record.data
-        }
-        OpenStruct.new(event_data)
+      def build_event_entity(record)
+        ::RailsEventStore::EventEntity.new(
+          id:         record.id,
+          stream:     record.stream,
+          event_type: record.event_type,
+          event_id:   record.event_id,
+          metadata:   record.metadata,
+          data:       record.data,
+          created_at: record.created_at
+        )
       end
+
     end
   end
 end

--- a/rails_event_store.gemspec
+++ b/rails_event_store.gemspec
@@ -24,7 +24,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rails', '~> 4.2.1'
   spec.add_development_dependency 'webmock', '~> 1.21.0'
+
   spec.add_dependency 'ruby_event_store'
   spec.add_dependency 'activesupport', '>= 3.0'
+  spec.add_dependency 'activemodel', '>= 3.0'
 
 end

--- a/spec/event_repository_spec.rb
+++ b/spec/event_repository_spec.rb
@@ -5,7 +5,7 @@ module RailsEventStore
 
     specify 'initialize proper adapter type' do
       repository = Repositories::EventRepository.new
-      expect(repository.adapter.model_name.name).to eq 'RailsEventStore::EventEntity'
+      expect(repository.adapter.model_name.name).to eq 'RailsEventStore::Models::Event'
     end
 
   end


### PR DESCRIPTION
Adds an explicit dependency on `activemodel`. Basically my mid-term goal is to build the `mongoid` adapter so I figured I should first start by refactoring how the repository pattern was applied here.

Thoughts and comments are welcome