### PR TITLE
fix: allow event entity to call methods on data

### DIFF
--- a/lib/rails_event_store/event_entity.rb
+++ b/lib/rails_event_store/event_entity.rb
@@ -6,5 +6,17 @@ module RailsEventStore
 
     attr_accessor :id, :stream, :event_type, :event_id,
                   :metadata, :data, :created_at
+
+    def method_missing(method_name, *args, &block)
+      data.send(method_name, *args, &block)
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      data.respond_to?(method_name)
+    end
+
+    def data
+      @_data ||= OpenStruct.new(@data)
+    end
   end
 end


### PR DESCRIPTION
Just found out that with the new implementation I proposed we now run into `NoMethodError` exceptions when re-playing the old events against the aggregate. Nevertheless the old solution, using the `OpenStruct`, was silently failing. At least we know it now :)