### PR TITLE
Use supported Rails methods for finding all events

### DIFF
--- a/lib/rails_event_store/repositories/event_repository.rb
+++ b/lib/rails_event_store/repositories/event_repository.rb
@@ -23,7 +23,7 @@ module RailsEventStore
       end
 
       def get_all_events
-        adapter.find(:all, order: 'stream').map &method(:build_event_entity)
+        adapter.order('id ASC').order('stream').all.map &method(:build_event_entity)
       end
 
       def last_stream_event(stream_name)


### PR DESCRIPTION
Rails doesn't seem to support `find(:all)` anymore, so I propose this fix.

How would you prefer this to be tested?
