### PR TITLE
Make RES compatible with the newest Ruby Event Store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gemspec
 gem 'codeclimate-test-reporter', group: :test, require: nil
+gem 'ruby_event_store', github: 'arkency/ruby_event_store'

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ end
 
 ```ruby
 invoice = InvoiceReadModel.new
-client.subscribe(invoice, ['PriceChanged', 'ProductAdded'])
+client.subscribe(invoice, [PriceChanged, ProductAdded])
 ```
 
 * You can also listen on all incoming events

--- a/lib/rails_event_store/event_handlers/slack_event_handler.rb
+++ b/lib/rails_event_store/event_handlers/slack_event_handler.rb
@@ -26,7 +26,7 @@ module RailsEventStore
       attr_reader :webhook_url, :http_client
 
       def handle_event(event)
-        event_name = event.event_type
+        event_name = event.class.name
         payload = {
           text: "Event #{event_name} raised.",
           username: "Rails EventStore Bot",

--- a/lib/rails_event_store/repositories/event_repository.rb
+++ b/lib/rails_event_store/repositories/event_repository.rb
@@ -89,12 +89,13 @@ module RailsEventStore
 
       def build_event_entity(record)
         return nil unless record
-        ::RailsEventStore::Event.new(record.data.merge(
-          event_type: record.event_type,
-          event_id:   record.event_id,
-          metadata:   record.metadata))
+        record.event_type.constantize.new(
+          record.data.merge(
+            event_id: record.event_id,
+            metadata: record.metadata
+          )
+        )
       end
-
     end
   end
 end

--- a/rails_event_store.gemspec
+++ b/rails_event_store.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 1.21'
   spec.add_development_dependency 'sqlite3'
 
-  spec.add_dependency 'ruby_event_store', '~> 0.3.1'
   spec.add_dependency 'aggregate_root', '~> 0'
   spec.add_dependency 'activesupport', '>= 3.0'
   spec.add_dependency 'activemodel', '>= 3.0'

--- a/spec/example_invoicing_app.rb
+++ b/spec/example_invoicing_app.rb
@@ -22,13 +22,12 @@ class InvoiceReadModel
   end
 
   def handle_event(event)
-    if event.event_type == "ProductAdded"
+    case event
+    when ProductAdded
       add_new_invoice_item(event.product_name)
       set_price(event.product_name, event.price)
       set_quantity(event.product_name, event.quantity)
-    end
-
-    if event.event_type == "PriceChanged"
+    when PriceChanged
       set_price(event.product_name, event.new_price)
     end
   end

--- a/spec/full_story_spec.rb
+++ b/spec/full_story_spec.rb
@@ -14,7 +14,7 @@ module RailsEventStore
     specify 'building a read model runtime - pub_sub' do
       client = Client.new
       invoice = InvoiceReadModel.new
-      client.subscribe(invoice, ['PriceChanged', 'ProductAdded'])
+      client.subscribe(invoice, [PriceChanged, ProductAdded])
       publish_ordering_events(client)
       assert_invoice_structure(invoice)
     end


### PR DESCRIPTION
The newest Ruby Event Store changed how event subscription work.
Currently event types are used rather than strings

currently:

```ruby
   es.subscribe(Handler, [OrderCreated])
```

before:

```ruby
   es.subscribe(Handler, ['OrderCreated'])
```

This commit makes RES work with the new approach.