### PR TITLE
Allow to read events backward

### DIFF
--- a/lib/rails_event_store/client.rb
+++ b/lib/rails_event_store/client.rb
@@ -26,15 +26,27 @@ module RailsEventStore
     end
     alias :read_events :read_events_forward
 
+    def read_events_backward(stream_name, start = :head, count = page_size)
+      event_store.read_events_backward(stream_name, start, count)
+    end
+
     def read_stream_events_forward(stream_name)
       event_store.read_stream_events_forward(stream_name)
     end
     alias :read_all_events :read_stream_events_forward
 
+    def read_stream_events_backward(stream_name)
+      event_store.read_stream_events_backward(stream_name)
+    end
+
     def read_all_streams_forward(start = :head, count = page_size)
       event_store.read_all_streams_forward(start, count)
     end
     alias :read_all_streams :read_all_streams_forward
+
+    def read_all_streams_backward(start = :head, count = page_size)
+      event_store.read_all_streams_backward(start, count)
+    end
 
     def subscribe(subscriber, event_types)
       event_store.subscribe(subscriber, event_types)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 module RailsEventStore
+  TestEvent = Class.new(RailsEventStore::Event)
+
   describe Client do
 
     specify 'initialize proper adapter type' do
@@ -13,19 +15,74 @@ module RailsEventStore
       expect(client.__send__("event_broker")).to be_a EventBroker
     end
 
-    specify 'read_all_streams' do
+    specify 'read events forward' do
       client = Client.new
-      expect(client.read_all_streams).to eq([])
+      client.publish_event(TestEvent.new(event_id: '1'), 'stream')
+      client.publish_event(TestEvent.new(event_id: '2'), 'stream')
+      client.publish_event(TestEvent.new(event_id: '3'), 'stream')
+      client.publish_event(TestEvent.new(event_id: '4'), 'other_stream')
+      client.publish_event(TestEvent.new(event_id: '5'), 'stream')
 
-      OrderPlaced = Class.new(RailsEventStore::Event)
-      client.publish_event(OrderPlaced.new(order_id: 1))
-      client.publish_event(OrderPlaced.new(order_id: 2), "stream-1")
-      client.publish_event(OrderPlaced.new(order_id: 3), "stream-2")
-      client.publish_event(OrderPlaced.new(order_id: 4), "stream-2")
+      expect(client.read_events_forward('stream').map(&:event_id)).to eq(['1', '2', '3', '5'])
+      expect(client.read_events_forward('stream', :head).map(&:event_id)).to eq(['1', '2', '3', '5'])
+      expect(client.read_events_forward('stream', '1').map(&:event_id)).to eq(['2', '3', '5'])
+      expect(client.read_events_forward('stream', '1', 2).map(&:event_id)).to eq(['2', '3'])
+    end
 
-      actuals = client.read_all_streams
-      expect(actuals.count).to eq 4
-      expect(actuals.map(&:order_id)).to eq [1,2,3,4]
+    specify 'read events backward' do
+      client = Client.new
+      client.publish_event(TestEvent.new(event_id: '1'), 'stream')
+      client.publish_event(TestEvent.new(event_id: '2'), 'stream')
+      client.publish_event(TestEvent.new(event_id: '3'), 'stream')
+      client.publish_event(TestEvent.new(event_id: '4'), 'other_stream')
+      client.publish_event(TestEvent.new(event_id: '5'), 'stream')
+
+      expect(client.read_events_backward('stream').map(&:event_id)).to eq(['5', '3', '2', '1'])
+      expect(client.read_events_backward('stream', :head).map(&:event_id)).to eq(['5', '3', '2', '1'])
+      expect(client.read_events_backward('stream', '3').map(&:event_id)).to eq(['2', '1'])
+      expect(client.read_events_backward('stream', '3', 1).map(&:event_id)).to eq(['2'])
+    end
+
+    specify 'read all stream events forward' do
+      client = Client.new
+      client.publish_event(TestEvent.new(event_id: '1'), 'stream')
+      client.publish_event(TestEvent.new(event_id: '2'), 'other_stream')
+      client.publish_event(TestEvent.new(event_id: '3'), 'stream')
+
+      expect(client.read_stream_events_forward('stream').map(&:event_id)).to eq(['1', '3'])
+    end
+
+    specify 'read all stream events backward' do
+      client = Client.new
+      client.publish_event(TestEvent.new(event_id: '1'), 'stream')
+      client.publish_event(TestEvent.new(event_id: '2'), 'other_stream')
+      client.publish_event(TestEvent.new(event_id: '3'), 'stream')
+
+      expect(client.read_stream_events_backward('stream').map(&:event_id)).to eq(['3', '1'])
+    end
+
+    specify 'read all streams forward' do
+      client = Client.new
+      client.publish_event(TestEvent.new(event_id: '1'))
+      client.publish_event(TestEvent.new(event_id: '2'), 'stream-1')
+      client.publish_event(TestEvent.new(event_id: '3'), 'stream-2')
+      client.publish_event(TestEvent.new(event_id: '4'), 'stream-2')
+
+      expect(client.read_all_streams_forward.map(&:event_id)).to eq(['1', '2', '3', '4'])
+      expect(client.read_all_streams_forward(:head, 3).map(&:event_id)).to eq(['1', '2', '3'])
+      expect(client.read_all_streams_forward('2', 2).map(&:event_id)).to eq(['3', '4'])
+    end
+
+    specify 'read all streams backward' do
+      client = Client.new
+      client.publish_event(TestEvent.new(event_id: '1'))
+      client.publish_event(TestEvent.new(event_id: '2'), 'stream-1')
+      client.publish_event(TestEvent.new(event_id: '3'), 'stream-2')
+      client.publish_event(TestEvent.new(event_id: '4'), 'stream-2')
+
+      expect(client.read_all_streams_backward.map(&:event_id)).to eq(['4', '3', '2', '1'])
+      expect(client.read_all_streams_backward(:head, 3).map(&:event_id)).to eq(['4', '3', '2'])
+      expect(client.read_all_streams_backward('4', 2).map(&:event_id)).to eq(['3', '2'])
     end
   end
 end


### PR DESCRIPTION
Just delegated methods responsible for reading events backward
to the repository.