### PR TITLE
Adds write lock strategy per aggregates

### DIFF
--- a/lib/rails_event_store/client.rb
+++ b/lib/rails_event_store/client.rb
@@ -3,10 +3,12 @@ module RailsEventStore
 
     def initialize(repository: RailsEventStoreActiveRecord::EventRepository.new,
                    event_broker: EventBroker.new,
+                   lock_obtainer: nil,
                    page_size: PAGE_SIZE)
       @repository = repository
       @page_size = page_size
       @event_broker = event_broker
+      @lock_obtainer = lock_obtainer
     end
 
     def publish_event(event, stream_name = GLOBAL_STREAM, expected_version = :any)
@@ -57,10 +59,10 @@ module RailsEventStore
     end
 
     private
-    attr_reader :repository, :page_size, :event_broker
+    attr_reader :repository, :page_size, :event_broker, :lock_obtainer
 
     def event_store
-      @event_store ||= RubyEventStore::Facade.new(repository, event_broker)
+      @event_store ||= RubyEventStore::Facade.new(repository, event_broker, lock_obtainer)
     end
   end
 end


### PR DESCRIPTION
#### Overview

This changes allow to perform a database lock per aggregates in order to avoid concurrency issues in a concurrent environment, such as, multi-threaded env or load balanced event store (multiple event store processes trying to create events on the database at the same time).

The lock only blocks the aggregate, not the entire event table. A `RubyEventStore::CannotObtainLock` exception is raised in case the lock could not be obtained. Meaning an event store was already trying to perform an `INSERT` on the given aggregate.

Client's implementation should catch this exception and perform a simple `retry` in a `begin`/`rescue` block:

``` ruby
aggregate_id = SecureRandom.uuid
client = RailsEventStore::Client.new(lock_obtainer: RailsEventStoreActiveRecord::LockObtainer.new)

begin
  event = OrderCreated.new(data: "sample", event_id: SecureRandom.uuid)
  client.publish_event(event, aggregate_id)
rescue RubyEventStore::CannotObtainLock
  retry
end
```
