### PR TITLE
Rails request details in event metadata.

### DIFF
--- a/lib/rails_event_store.rb
+++ b/lib/rails_event_store.rb
@@ -11,3 +11,4 @@ end
 require 'rails_event_store/version'
 require 'rails_event_store/client'
 require 'rails_event_store/constants'
+require 'rails_event_store/railtie' if defined?(Rails::Railtie)

--- a/lib/rails_event_store/client.rb
+++ b/lib/rails_event_store/client.rb
@@ -10,7 +10,9 @@ module RailsEventStore
     end
 
     def publish_event(event, stream_name = GLOBAL_STREAM, expected_version = :any)
-      event_store.publish_event(event, stream_name, expected_version)
+      captured_metadata = Thread.current[:rails_event_store] || {}
+      enriched_event = event.class.new(event_id: event.event_id, metadata: captured_metadata.merge(event.metadata), **event.data)
+      event_store.publish_event(enriched_event, stream_name, expected_version)
     end
 
     def append_to_stream(event, stream_name = GLOBAL_STREAM, expected_version = :any)

--- a/lib/rails_event_store/middleware.rb
+++ b/lib/rails_event_store/middleware.rb
@@ -1,0 +1,20 @@
+module RailsEventStore
+  class Middleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      dup._call(env)
+    end
+
+    def _call(env)
+      Thread.current[:rails_event_store] =
+        { remote_ip: ActionDispatch::Request.new(env).remote_ip }
+      @app.call(env)
+    ensure
+      Thread.current[:rails_event_store] = nil
+      body.close if body && body.respond_to?(:close) && $!
+    end
+  end
+end

--- a/lib/rails_event_store/middleware.rb
+++ b/lib/rails_event_store/middleware.rb
@@ -1,7 +1,8 @@
 module RailsEventStore
   class Middleware
-    def initialize(app)
+    def initialize(app, request_metadata)
       @app = app
+      @request_metadata = request_metadata
     end
 
     def call(env)
@@ -9,8 +10,7 @@ module RailsEventStore
     end
 
     def _call(env)
-      Thread.current[:rails_event_store] =
-        { remote_ip: ActionDispatch::Request.new(env).remote_ip }
+      Thread.current[:rails_event_store] = @request_metadata.(env)
       @app.call(env)
     ensure
       Thread.current[:rails_event_store] = nil

--- a/lib/rails_event_store/railtie.rb
+++ b/lib/rails_event_store/railtie.rb
@@ -3,7 +3,28 @@ require 'rails_event_store/middleware'
 module RailsEventStore
   class Railtie < ::Rails::Railtie
     initializer 'rails_event_store.middleware' do |rails|
-      rails.middleware.use ::RailsEventStore::Middleware
+      rails.middleware.use(::RailsEventStore::Middleware, RailsConfig.new(rails.config).request_metadata)
+    end
+
+    class RailsConfig
+      def initialize(config)
+        @config = config
+      end
+
+      def request_metadata
+        return default_request_metadata unless @config.respond_to?(:rails_event_store)
+        @config.rails_event_store.fetch(:request_metadata, default_request_metadata)
+      end
+
+      private
+      def default_request_metadata
+        ->(env) do
+          request = ActionDispatch::Request.new(env)
+          { remote_ip:  request.remote_ip,
+            request_id: request.uuid,
+          }
+        end
+      end
     end
   end
 end

--- a/lib/rails_event_store/railtie.rb
+++ b/lib/rails_event_store/railtie.rb
@@ -1,0 +1,10 @@
+require 'rails_event_store/middleware'
+
+module RailsEventStore
+  class Railtie < ::Rails::Railtie
+    initializer 'rails_event_store.middleware' do |rails|
+      rails.middleware.use ::RailsEventStore::Middleware
+    end
+  end
+end
+

--- a/rails_event_store.gemspec
+++ b/rails_event_store.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rails', '~> 4.2'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'rack-test'
 
   spec.add_dependency 'ruby_event_store', '~> 0.9.0'
   spec.add_dependency 'rails_event_store_active_record', '~> 0.6.3'

--- a/spec/request_metadata_spec.rb
+++ b/spec/request_metadata_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'action_controller/railtie'
+require 'rack/test'
+require 'securerandom'
+
+
+class TestRails
+  include Rack::Test::Methods
+
+  attr_reader :app
+
+  def initialize
+    @app = Class.new(::Rails::Application)
+  end
+
+  def call(action)
+    app.config.secret_key_base = SecureRandom.hex
+    app.config.eager_load = false
+    app.initialize!
+    app.routes.draw { root(to: ->(env) { action.(); [200, {}, ['']] }) }
+    app.default_url_options = { host: 'example.com' }
+    get('/')
+  end
+end
+
+module RailsEventStore
+  DummyEvent = Class.new(RailsEventStore::Event)
+
+  RSpec.describe 'request details in event metadata' do
+    specify do
+      event_store = Client.new
+
+      TestRails.new.(->(env) { event_store.publish_event(DummyEvent.new) })
+
+      expect(event_store.read_all_events(GLOBAL_STREAM))
+        .to_not(be_empty)
+      event_store.read_all_events(GLOBAL_STREAM)
+        .map  { |event|    event.metadata }
+        .each { |metadata| expect(metadata).to(include(remote_ip: '127.0.0.1')) }
+    end
+  end
+end

--- a/spec/request_metadata_spec.rb
+++ b/spec/request_metadata_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'action_controller/railtie'
+require 'rails_event_store/railtie'
 require 'rack/test'
 require 'securerandom'
 
@@ -30,7 +31,7 @@ module RailsEventStore
     specify do
       event_store = Client.new
 
-      TestRails.new.(->(env) { event_store.publish_event(DummyEvent.new) })
+      TestRails.new.(->{ event_store.publish_event(DummyEvent.new) })
 
       expect(event_store.read_all_events(GLOBAL_STREAM))
         .to_not(be_empty)

--- a/spec/request_metadata_spec.rb
+++ b/spec/request_metadata_spec.rb
@@ -10,13 +10,18 @@ class TestRails
 
   attr_reader :app
 
-  def initialize
+  def initialize(test_config = {})
     @app = Class.new(::Rails::Application)
+    @test_config = test_config
   end
 
   def call(action)
-    app.config.secret_key_base = SecureRandom.hex
-    app.config.eager_load = false
+    @test_config
+      .merge(
+        { eager_load: false,
+          secret_key_base: SecureRandom.hex
+        })
+      .each { |k, v| app.config.send("#{k}=", v) }
     app.initialize!
     app.routes.draw { root(to: ->(env) { action.(); [200, {}, ['']] }) }
     app.default_url_options = { host: 'example.com' }
@@ -28,10 +33,23 @@ module RailsEventStore
   DummyEvent = Class.new(RailsEventStore::Event)
 
   RSpec.describe 'request details in event metadata' do
-    specify do
+    specify 'no config' do
       event_store = Client.new
 
       TestRails.new.(->{ event_store.publish_event(DummyEvent.new) })
+
+      expect(event_store.read_all_events(GLOBAL_STREAM))
+        .to_not(be_empty)
+      event_store.read_all_events(GLOBAL_STREAM)
+        .map  { |event|    event.metadata }
+        .each { |metadata| expect(metadata.keys).to(include(:remote_ip, :request_id)) }
+    end
+
+    specify 'custom config' do
+      event_store = Client.new
+
+      TestRails.new(rails_event_store: { request_metadata: ->(env) { { remote_ip: env['REMOTE_ADDR'] } } })
+        .(->{ event_store.publish_event(DummyEvent.new) })
 
       expect(event_store.read_all_events(GLOBAL_STREAM))
         .to_not(be_empty)


### PR DESCRIPTION
The idea behind it is to automatically record some data not directly related to particular
event but useful in context of audit log.

What (if anything) to be recorded can be made confifgurable,I wanted to deliver working prototype first.

Possbily interesting stuff to record:
- user agent
- request id (i.e. to use as a correlation id for group of events)
- logged in user identifier (with help of some popular solutions like Devise)