### PR TITLE
Fixed naming clash in examples provided on the publish page

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -3,19 +3,19 @@
 Firstly you have to define own event model extending `RailsEventStore::Event` class.
 
 ```ruby
-class OrderCreated < RailsEventStore::Event
+class OrderPlaced < RailsEventStore::Event
 end
 
 # or
 
-OrderCreated = Class.new(RailsEventStore::Event)
+OrderPlaced = Class.new(RailsEventStore::Event)
 ```
 
 ```ruby
 stream_name = "order_1"
-event = OrderCreated.new(
-          data: "sample",
-          event_id: "b2d506fd-409d-4ec7-b02f-c6d2295c7edd"
+event = OrderPlaced.new(
+          order_data: "sample",
+          festival_id: "b2d506fd-409d-4ec7-b02f-c6d2295c7edd"
         )
 #publishing event for specific stream
 client.publish_event(event, stream_name)
@@ -27,15 +27,15 @@ client.publish_event(event)
 # Creating new event with optimistic locking:
 
 ```ruby
-class OrderCreated < RailsEventStore::Event
+class OrderPlaced < RailsEventStore::Event
 end
 ```
 
 ```ruby
 stream_name = "order_1"
-event = OrderCreated.new(
-          data: "sample",
-          event_id: "b2d506fd-409d-4ec7-b02f-c6d2295c7edd"
+event = OrderPlaced.new(
+          order_data: "sample",
+          festival_id: "b2d506fd-409d-4ec7-b02f-c6d2295c7edd"
         )
 expected_version = "850c347f-423a-4158-a5ce-b885396c5b73" #last event_id
 client.publish_event(event, stream_name, expected_version)
@@ -47,9 +47,9 @@ In order to skip handlers you can just append event to a stream.
 
 ```ruby
 stream_name = "order_1"
-event = OrderCreated.new(
-          data: "sample",
-          event_id: "b2d506fd-409d-4ec7-b02f-c6d2295c7edd"
+event = OrderPlaced.new(
+          order_data: "sample",
+          festival_id: "b2d506fd-409d-4ec7-b02f-c6d2295c7edd"
         )
 client.append_to_stream(event, stream_name)
 ```


### PR DESCRIPTION
rebuilt docs with a newer version of gitbook, served it locally and it looks fine