### PR TITLE
Useless safety measure.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test: ## Run tests
 
 mutate: test  ## Run mutation tests
 	@echo "Running mutation tests - only 100% free mutation will be accepted"
-	@bundle exec mutant --include lib --require rails_event_store --use rspec "RailsEventStore*" --expected-coverage 515/612
+	@bundle exec mutant --include lib --require rails_event_store --use rspec "RailsEventStore*" --expected-coverage 515/576
 
 .PHONY: help
 

--- a/lib/rails_event_store/middleware.rb
+++ b/lib/rails_event_store/middleware.rb
@@ -14,7 +14,6 @@ module RailsEventStore
       @app.call(env)
     ensure
       Thread.current[:rails_event_store] = nil
-      body.close if body && body.respond_to?(:close) && $!
     end
   end
 end


### PR DESCRIPTION
- would not work, I've mistakenly removed following code previously:

    status, headers, body = @app.call(env)
    # after actions
    return status, headers, body

- there are no after actions which could raise exception after body is
  set
- if body is not set, that's no-op