### PR TITLE
Removes ActiveRecord dependencies

### DIFF
--- a/lib/rails_event_store.rb
+++ b/lib/rails_event_store.rb
@@ -1,14 +1,14 @@
 require 'ruby_event_store'
-require 'rails_event_store_active_record'
 
 module RailsEventStore
-  Event               = RubyEventStore::Event
-  InMemoryRepository  = RubyEventStore::InMemoryRepository
-  EventBroker         = RubyEventStore::PubSub::Broker
-  Projection          = RubyEventStore::Projection
+  Event           = RubyEventStore::Event
+  EventBroker     = RubyEventStore::PubSub::Broker
+  EventRepository = RubyEventStore::InMemoryRepository
+  Projection      = RubyEventStore::Projection
 end
 
 require 'rails_event_store/version'
+require 'rails_event_store/event_repository'
 require 'rails_event_store/client'
 require 'rails_event_store/constants'
 require 'rails_event_store/railtie' if defined?(Rails::Railtie)

--- a/lib/rails_event_store/client.rb
+++ b/lib/rails_event_store/client.rb
@@ -1,7 +1,7 @@
 module RailsEventStore
   class Client
 
-    def initialize(repository: RailsEventStoreActiveRecord::EventRepository.new,
+    def initialize(repository: EventRepository.new,
                    event_broker: EventBroker.new,
                    page_size: PAGE_SIZE)
       @repository = repository

--- a/lib/rails_event_store/event_repository.rb
+++ b/lib/rails_event_store/event_repository.rb
@@ -1,0 +1,11 @@
+module RailsEventStore
+  if defined?(RailsEventStoreActiveRecord)
+    require 'rails_event_store_active_record'
+    EventRepository = RailsEventStoreActiveRecord::EventRepository
+  end
+
+  if defined?(RailsEventStoreMongoid)
+    require 'rails_event_store_mongoid'
+    EventRepository = RailsEventStoreMongoid::EventRepository
+  end
+end

--- a/rails_event_store.gemspec
+++ b/rails_event_store.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack-test'
 
   spec.add_dependency 'ruby_event_store', '~> 0.12.0'
-  spec.add_dependency 'rails_event_store_active_record', '~> 0.6.7'
   spec.add_dependency 'aggregate_root', '~> 0.3.5'
   spec.add_dependency 'activesupport', '>= 3.0'
   spec.add_dependency 'activemodel', '>= 3.0'

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -7,7 +7,7 @@ module RailsEventStore
 
     specify 'initialize proper adapter type' do
       client = Client.new
-      expect(client.__send__("repository")).to be_a RailsEventStoreActiveRecord::EventRepository
+      expect(client.__send__("repository")).to be_a EventRepository
     end
 
     specify 'initialize proper event broker type' do

--- a/spec/middleware_integration_spec.rb
+++ b/spec/middleware_integration_spec.rb
@@ -5,13 +5,16 @@ require 'rack/lint'
 
 module RailsEventStore
   RSpec.describe Middleware do
-    DummyEvent = Class.new(RailsEventStore::Event)
+
+    let(:dummy_event_class) do
+      Class.new(RailsEventStore::Event)
+    end
 
     specify do
       event_store = Client.new
 
       request = ::Rack::MockRequest.new(Middleware.new(
-        ->(env) { event_store.publish_event(DummyEvent.new); [200, {}, ["Hello World from #{env["SERVER_NAME"]}"]] },
+        ->(env) { event_store.publish_event(dummy_event_class.new); [200, {}, ["Hello World from #{env["SERVER_NAME"]}"]] },
         ->(env) { { server_name: env['SERVER_NAME'] }}))
       request.get('/')
 
@@ -21,5 +24,3 @@ module RailsEventStore
     end
   end
 end
-
-

--- a/spec/request_metadata_spec.rb
+++ b/spec/request_metadata_spec.rb
@@ -2,14 +2,18 @@ require 'spec_helper'
 require 'support/test_rails'
 
 module RailsEventStore
-  DummyEvent = Class.new(RailsEventStore::Event)
   UUID_REGEX = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
 
   RSpec.describe Client do
+
+    let(:dummy_event_class) do
+      Class.new(RailsEventStore::Event)
+    end
+
     specify 'no config' do
       event_store = Client.new
 
-      TestRails.new.(->{ event_store.publish_event(DummyEvent.new) })
+      TestRails.new.(->{ event_store.publish_event(dummy_event_class.new) })
 
       expect(event_store.read_events_forward(GLOBAL_STREAM)).to_not be_empty
       event_store.read_events_forward(GLOBAL_STREAM).map(&:metadata).each do |metadata|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,25 +6,3 @@ end
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rails_event_store'
 require 'example_invoicing_app'
-
-RSpec.configure do |config|
-  config.around(:each) do |example|
-    ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
-    ActiveRecord::Schema.define do
-      self.verbose = false
-      create_table(:event_store_events) do |t|
-        t.string      :stream,      null: false
-        t.string      :event_type,  null: false
-        t.string      :event_id,    null: false
-        t.text        :metadata
-        t.text        :data,        null: false
-        t.datetime    :created_at,  null: false
-      end
-      add_index :event_store_events, :stream
-      add_index :event_store_events, :created_at
-      add_index :event_store_events, :event_type
-      add_index :event_store_events, :event_id, unique: true
-    end
-    example.run
-  end
-end


### PR DESCRIPTION
This is a breaking change since we will not default on the active record
event repository anymore.
Clients will need to explicitely use the proper RailsEventStore repository in
their Gemfile.

Before:

``` ruby
gem 'rails_event_store'
```

After:

``` ruby
gem 'rails_event_store'
gem 'rails_event_store_active_record'
```

Nevertheless, the gem will automatically load the proper repository.
No need to explicitely set the repository when instantiating the event store:

``` ruby
RailsEventStore::Client.new(repository: RailsEventStoreActiveRecord::EventRepository.new)
```

The goal is to prepare the code base to handle other ORM adapters, such as [Mongoid](https://github.com/gottfrois/rails_event_store_mongoid).
