### PR TITLE
Allows to specify repository adapter to use

### DIFF
--- a/lib/rails_event_store.rb
+++ b/lib/rails_event_store.rb
@@ -1,25 +1,25 @@
 require 'ruby_event_store'
-require 'rails_event_store_active_record'
 
 module RailsEventStore
-  Event               = RubyEventStore::Event
-  InMemoryRepository  = RubyEventStore::InMemoryRepository
-  EventBroker         = RubyEventStore::PubSub::Broker
-  Projection          = RubyEventStore::Projection
-
-  GLOBAL_STREAM       = RubyEventStore::GLOBAL_STREAM
-  PAGE_SIZE           = RubyEventStore::PAGE_SIZE
-
-  WrongExpectedEventVersion  = RubyEventStore::WrongExpectedEventVersion
-  InvalidExpectedVersion     = RubyEventStore::InvalidExpectedVersion
-  IncorrectStreamData        = RubyEventStore::IncorrectStreamData
-  EventNotFound              = RubyEventStore::EventNotFound
-  SubscriberNotExist         = RubyEventStore::SubscriberNotExist
-  MethodNotDefined           = RubyEventStore::MethodNotDefined
-  InvalidPageStart           = RubyEventStore::InvalidPageStart
-  InvalidPageSize            = RubyEventStore::InvalidPageSize
+  GLOBAL_STREAM             = RubyEventStore::GLOBAL_STREAM
+  PAGE_SIZE                 = RubyEventStore::PAGE_SIZE
+  Event                     = RubyEventStore::Event
+  EventBroker               = RubyEventStore::PubSub::Broker
+  Projection                = RubyEventStore::Projection
+  WrongExpectedEventVersion = RubyEventStore::WrongExpectedEventVersion
+  InvalidExpectedVersion    = RubyEventStore::InvalidExpectedVersion
+  IncorrectStreamData       = RubyEventStore::IncorrectStreamData
+  EventNotFound             = RubyEventStore::EventNotFound
+  SubscriberNotExist        = RubyEventStore::SubscriberNotExist
+  MethodNotDefined          = RubyEventStore::MethodNotDefined
+  InvalidPageStart          = RubyEventStore::InvalidPageStart
+  InvalidPageSize           = RubyEventStore::InvalidPageSize
 end
 
 require 'rails_event_store/version'
+require 'rails_event_store/repository'
 require 'rails_event_store/client'
 require 'rails_event_store/railtie' if defined?(Rails::Railtie)
+
+# Use active_record adapter by default
+RailsEventStore::Repository.adapter = :active_record

--- a/lib/rails_event_store.rb
+++ b/lib/rails_event_store.rb
@@ -3,6 +3,7 @@ require 'ruby_event_store'
 module RailsEventStore
   GLOBAL_STREAM             = RubyEventStore::GLOBAL_STREAM
   PAGE_SIZE                 = RubyEventStore::PAGE_SIZE
+  InMemoryRepository        = RubyEventStore::InMemoryRepository
   Event                     = RubyEventStore::Event
   EventBroker               = RubyEventStore::PubSub::Broker
   Projection                = RubyEventStore::Projection

--- a/lib/rails_event_store/client.rb
+++ b/lib/rails_event_store/client.rb
@@ -1,6 +1,6 @@
 module RailsEventStore
   class Client < RubyEventStore::Client
-    def initialize(repository: RailsEventStoreActiveRecord::EventRepository.new,
+    def initialize(repository: RailsEventStore::Repository.adapter,
                    event_broker: EventBroker.new,
                    page_size: PAGE_SIZE)
       capture_metadata = ->{ Thread.current[:rails_event_store] }

--- a/lib/rails_event_store/client.rb
+++ b/lib/rails_event_store/client.rb
@@ -1,6 +1,6 @@
 module RailsEventStore
   class Client < RubyEventStore::Client
-    def initialize(repository: RailsEventStore::Repository.adapter,
+    def initialize(repository: Repository.adapter,
                    event_broker: EventBroker.new,
                    page_size: PAGE_SIZE)
       capture_metadata = ->{ Thread.current[:rails_event_store] }

--- a/lib/rails_event_store/repository.rb
+++ b/lib/rails_event_store/repository.rb
@@ -1,0 +1,19 @@
+require 'active_support/core_ext/class/attribute_accessors'
+
+module RailsEventStore
+  class Repository
+    cattr_reader :adapter
+
+    def self.adapter=(adapter)
+      case adapter.to_s
+      when 'in_memory'
+        @@adapter = ::RubyEventStore::InMemoryRepository
+      when String
+        require "rails_event_store_#{adapter}"
+        @@adapter = "::RailsEventStore#{adapter.to_s.classify}::EventRepository".constantize.new
+      else
+        @@adapter = adapter
+      end
+    end
+  end
+end

--- a/lib/rails_event_store/repository.rb
+++ b/lib/rails_event_store/repository.rb
@@ -5,10 +5,8 @@ module RailsEventStore
     cattr_reader :adapter
 
     def self.adapter=(adapter)
-      case adapter.to_s
-      when 'in_memory'
-        @@adapter = ::RubyEventStore::InMemoryRepository
-      when String
+      case adapter
+      when String, Symbol
         require "rails_event_store_#{adapter}"
         @@adapter = "::RailsEventStore#{adapter.to_s.classify}::EventRepository".constantize.new
       else

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -4,7 +4,7 @@ module RailsEventStore
   describe Client do
     specify 'initialize proper adapter type' do
       client = Client.new
-      expect(client.__send__("repository")).to be_a RailsEventStoreActiveRecord::EventRepository
+      expect(client.__send__("repository")).to be_a RailsEventStore::Repository.adapter.class
       expect(client.__send__("page_size")).to eq RailsEventStore::PAGE_SIZE
     end
 
@@ -17,6 +17,12 @@ module RailsEventStore
       CustomEventBroker = Class.new
       client = Client.new(event_broker: CustomEventBroker.new)
       expect(client.__send__("event_broker")).to be_a CustomEventBroker
+    end
+
+    specify 'may take custom repository' do
+      CustomRepository = Class.new
+      client = Client.new(repository: CustomRepository.new)
+      expect(client.__send__("repository")).to be_a CustomRepository
     end
 
     specify 'initialize custom page size' do

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+RSpec.describe RailsEventStore::Repository do
+
+  subject(:adapter) { described_class.adapter }
+
+  after :all do
+    described_class.adapter = :active_record
+  end
+
+  describe '.adapter=' do
+
+    context 'when passing nil' do
+
+      before do
+        described_class.adapter = nil
+      end
+
+      it { is_expected.to eq(nil) }
+
+    end
+
+    context 'when passing a string' do
+
+      context 'which module does not exists' do
+
+        it { expect { described_class.adapter = 'foo' }.to raise_exception(LoadError) }
+
+      end
+
+      context 'which module exists' do
+
+        before do
+          described_class.adapter = 'active_record'
+        end
+
+        it { is_expected.to be_a(RailsEventStoreActiveRecord::EventRepository) }
+
+      end
+
+      context 'when passing a symbol' do
+
+        context 'which module does not exists' do
+
+          it { expect { described_class.adapter = :foo }.to raise_exception(LoadError) }
+
+        end
+
+        context 'which module exists' do
+
+          before do
+            described_class.adapter = :active_record
+          end
+
+          it { is_expected.to be_a(RailsEventStoreActiveRecord::EventRepository) }
+
+        end
+
+      end
+
+    end
+
+    context 'when passing an object' do
+
+      let(:adapter_class) do
+        Class.new
+      end
+      let(:adapter) { adapter_class.new }
+
+      before do
+        described_class.adapter = adapter
+      end
+
+      it { is_expected.to eq(adapter) }
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
@mpraglowski would this approach be ok with your vision? It use active_record by default but allows to plug any other repository adapter.

Usage:

```
gem 'rails_event_store'
```

That's it. If we want to change the adapter, for example in `rails_event_store_mongoid`:

```
gem 'rails_event_store'
gem 'rails_event_store_mongoid'
```

That's it, the `rails_event_store_mongoid` will do internaly:

```
RailsEventStore::Repository.adapter = :mongoid
```

While updating my previous PR I notice that I actually don't want to re-create a clone of RailsEventStore that would know how to deal with Mongoid. If we do that, any "nice feature to have" that we include in RailsEventStore will need to be copied over other gems. The goodies given by the railties present in RailsEventStore gem are a good example.

If you are ok with this approach, I'll write tests for it.
Please let me know