### PR TITLE
Allows to set the event repository used.

### DIFF
--- a/lib/rails_event_store.rb
+++ b/lib/rails_event_store.rb
@@ -1,25 +1,5 @@
-require 'ruby_event_store'
 require 'rails_event_store_active_record'
+require 'rails_event_store/all'
 
-module RailsEventStore
-  Event               = RubyEventStore::Event
-  InMemoryRepository  = RubyEventStore::InMemoryRepository
-  EventBroker         = RubyEventStore::PubSub::Broker
-  Projection          = RubyEventStore::Projection
-
-  GLOBAL_STREAM       = RubyEventStore::GLOBAL_STREAM
-  PAGE_SIZE           = RubyEventStore::PAGE_SIZE
-
-  WrongExpectedEventVersion  = RubyEventStore::WrongExpectedEventVersion
-  InvalidExpectedVersion     = RubyEventStore::InvalidExpectedVersion
-  IncorrectStreamData        = RubyEventStore::IncorrectStreamData
-  EventNotFound              = RubyEventStore::EventNotFound
-  SubscriberNotExist         = RubyEventStore::SubscriberNotExist
-  MethodNotDefined           = RubyEventStore::MethodNotDefined
-  InvalidPageStart           = RubyEventStore::InvalidPageStart
-  InvalidPageSize            = RubyEventStore::InvalidPageSize
-end
-
-require 'rails_event_store/version'
-require 'rails_event_store/client'
-require 'rails_event_store/railtie' if defined?(Rails::Railtie)
+# Use active record by default
+RailsEventStore::Repository.adapter = :active_record

--- a/lib/rails_event_store/all.rb
+++ b/lib/rails_event_store/all.rb
@@ -1,0 +1,21 @@
+require 'ruby_event_store'
+require 'rails_event_store/repository'
+require 'rails_event_store/client'
+require 'rails_event_store/version'
+
+module RailsEventStore
+  Event                     = RubyEventStore::Event
+  InMemoryRepository        = RubyEventStore::InMemoryRepository
+  EventBroker               = RubyEventStore::PubSub::Broker
+  Projection                = RubyEventStore::Projection
+  WrongExpectedEventVersion = RubyEventStore::WrongExpectedEventVersion
+  InvalidExpectedVersion    = RubyEventStore::InvalidExpectedVersion
+  IncorrectStreamData       = RubyEventStore::IncorrectStreamData
+  EventNotFound             = RubyEventStore::EventNotFound
+  SubscriberNotExist        = RubyEventStore::SubscriberNotExist
+  MethodNotDefined          = RubyEventStore::MethodNotDefined
+  InvalidPageStart          = RubyEventStore::InvalidPageStart
+  InvalidPageSize           = RubyEventStore::InvalidPageSize
+  GLOBAL_STREAM             = RubyEventStore::GLOBAL_STREAM
+  PAGE_SIZE                 = RubyEventStore::PAGE_SIZE
+end

--- a/lib/rails_event_store/client.rb
+++ b/lib/rails_event_store/client.rb
@@ -1,6 +1,6 @@
 module RailsEventStore
   class Client < RubyEventStore::Client
-    def initialize(repository: RailsEventStoreActiveRecord::EventRepository.new,
+    def initialize(repository: Repository.adapter,
                    event_broker: EventBroker.new,
                    page_size: PAGE_SIZE)
       capture_metadata = ->{ Thread.current[:rails_event_store] }

--- a/lib/rails_event_store/repository.rb
+++ b/lib/rails_event_store/repository.rb
@@ -1,0 +1,16 @@
+require 'active_support/core_ext/class/attribute_accessors'
+
+module RailsEventStore
+  class Repository
+    cattr_reader :adapter
+
+    def self.adapter=(adapter)
+      case adapter
+      when String, Symbol
+        @@adapter = "::RailsEventStore#{adapter.to_s.classify}::EventRepository".constantize.new
+      else
+        @@adapter = adapter
+      end
+    end
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -4,7 +4,7 @@ module RailsEventStore
   describe Client do
     specify 'initialize proper adapter type' do
       client = Client.new
-      expect(client.__send__("repository")).to be_a RailsEventStoreActiveRecord::EventRepository
+      expect(client.__send__("repository")).to be_a RailsEventStore::Repository.adapter.class
       expect(client.__send__("page_size")).to eq RailsEventStore::PAGE_SIZE
     end
 
@@ -17,6 +17,12 @@ module RailsEventStore
       CustomEventBroker = Class.new
       client = Client.new(event_broker: CustomEventBroker.new)
       expect(client.__send__("event_broker")).to be_a CustomEventBroker
+    end
+
+    specify 'may take custom repository' do
+      CustomRepository = Class.new
+      client = Client.new(repository: CustomRepository.new)
+      expect(client.__send__("repository")).to be_a CustomRepository
     end
 
     specify 'initialize custom page size' do

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+RSpec.describe RailsEventStore::Repository do
+
+  subject(:adapter) { described_class.adapter }
+
+  after :all do
+    described_class.adapter = :active_record
+  end
+
+  describe '.adapter=' do
+
+    context 'when passing nil' do
+
+      before do
+        described_class.adapter = nil
+      end
+
+      it { is_expected.to eq(nil) }
+
+    end
+
+    context 'when passing a string' do
+
+      context 'which module exists' do
+
+        before do
+          described_class.adapter = 'active_record'
+        end
+
+        it { is_expected.to be_a(RailsEventStoreActiveRecord::EventRepository) }
+
+      end
+
+      context 'when passing a symbol' do
+
+        context 'which module exists' do
+
+          before do
+            described_class.adapter = :active_record
+          end
+
+          it { is_expected.to be_a(RailsEventStoreActiveRecord::EventRepository) }
+
+        end
+
+      end
+
+    end
+
+    context 'when passing an object' do
+
+      let(:adapter_class) do
+        Class.new
+      end
+      let(:adapter) { adapter_class.new }
+
+      before do
+        described_class.adapter = adapter
+      end
+
+      it { is_expected.to eq(adapter) }
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
By default it will use the active_record event repository. If you want to
use another event repository without loading unecessary active_record
dependency, you'll need to do:

```
gem 'rails_event_store', require: false
gem 'rails_event_store_mongoid'
```

Then require manually `rails_event_store` gem dy doing:

```
require 'rails_event_store/all'
```

This will prevent loading `rails_event_store_active_record` gem by default.

Finally, specify the event repository adapter with:

```
RailsEventStore::Repository.adapter = :mongoid
```

It will look for a class named `RailsEventStoreMongoid::EventRepository`

### Help Needed to kill the mutants

@mpraglowski I was not able to kill the last mutant. Can you give me a hand?

```
RailsEventStore::Repository.adapter=:/Users/gottfrois/Code/rails_event_store/lib/rails_event_store/repository.rb:7
- rspec:16:./spec/repository_spec.rb:19/RailsEventStore::Repository.adapter= when passing nil
- rspec:17:./spec/repository_spec.rb:31/RailsEventStore::Repository.adapter= when passing a string which module exists
- rspec:18:./spec/repository_spec.rb:43/RailsEventStore::Repository.adapter= when passing a string when passing a symbol which module exists
- rspec:19:./spec/repository_spec.rb:62/RailsEventStore::Repository.adapter= when passing an object
evil:RailsEventStore::Repository.adapter=:/Users/gottfrois/Code/rails_event_store/lib/rails_event_store/repository.rb:7:54d08
@@ -1,9 +1,9 @@
 def self.adapter=(adapter)
   case adapter
   when String, Symbol
     @@adapter = "#{"::RailsEventStore"}#{adapter.to_s.classify}#{"::EventRepository"}".constantize.new
   else
-    @@adapter = adapter
+    @@adapter = nil
   end
 end
```