### PR TITLE
Fixes where is initialized event repository

### DIFF
--- a/lib/rails_event_store.rb
+++ b/lib/rails_event_store.rb
@@ -1,15 +1,5 @@
-require 'active_support/core_ext/class/attribute_accessors'
 require 'rails_event_store_active_record'
 require 'rails_event_store/all'
-
-module RailsEventStore
-  mattr_reader :event_repository
-
-  def self.event_repository=(event_repository)
-    raise ArgumentError unless event_repository
-    @@event_repository = event_repository
-  end
-end
 
 # Use active record by default
 RailsEventStore.event_repository = RailsEventStoreActiveRecord::EventRepository.new

--- a/lib/rails_event_store/all.rb
+++ b/lib/rails_event_store/all.rb
@@ -1,3 +1,4 @@
+require 'active_support/core_ext/class/attribute_accessors'
 require 'ruby_event_store'
 require 'rails_event_store/client'
 require 'rails_event_store/version'
@@ -17,4 +18,11 @@ module RailsEventStore
   InvalidPageSize           = RubyEventStore::InvalidPageSize
   GLOBAL_STREAM             = RubyEventStore::GLOBAL_STREAM
   PAGE_SIZE                 = RubyEventStore::PAGE_SIZE
+
+  mattr_reader :event_repository
+
+  def self.event_repository=(event_repository)
+    raise ArgumentError unless event_repository
+    @@event_repository = event_repository
+  end
 end


### PR DESCRIPTION
The event repository initialization must happen inside `all.rb` since on other repo (mongoid for example) we don't require `rails_event_store.rb` but only `rails_event_store/all.rb`