### PR TITLE
Require the railtie

### DIFF
--- a/lib/rails_event_store/all.rb
+++ b/lib/rails_event_store/all.rb
@@ -2,6 +2,7 @@ require 'active_support/core_ext/class/attribute_accessors'
 require 'ruby_event_store'
 require 'rails_event_store/client'
 require 'rails_event_store/version'
+require 'rails_event_store/railtie'
 
 module RailsEventStore
   Event                     = RubyEventStore::Event

--- a/lib/rails_event_store/railtie.rb
+++ b/lib/rails_event_store/railtie.rb
@@ -1,3 +1,4 @@
+require 'rails/railtie'
 require 'rails_event_store/middleware'
 
 module RailsEventStore


### PR DESCRIPTION
Otherwise the rack middleware is not added to the Rails stack
and events are not enriched with request metadata.